### PR TITLE
fix: AIMLChatEngine.continue_chat must accept tools kwarg

### DIFF
--- a/ovos_solver_aiml_plugin/__init__.py
+++ b/ovos_solver_aiml_plugin/__init__.py
@@ -6,6 +6,11 @@ from os.path import dirname, isfile, isdir, join
 from typing import List, Optional
 
 from ovos_plugin_manager.templates.agents import ChatEngine, AgentMessage, MessageRole
+
+try:
+    from ovos_plugin_manager.templates.agents import ToolsArg
+except ImportError:  # pragma: no cover - older ovos-plugin-manager
+    ToolsArg = None
 from ovos_utils.log import LOG
 from ovos_utils.xdg_utils import xdg_data_home
 
@@ -210,12 +215,18 @@ class AIMLChatEngine(ChatEngine):
     def continue_chat(self, messages: List[AgentMessage],
                       session_id: str = "default",
                       lang: Optional[str] = None,
-                      units: Optional[str] = None) -> AgentMessage:
+                      units: Optional[str] = None,
+                      tools: "ToolsArg" = None) -> AgentMessage:
         """Answer the latest user message via the AIML brain.
 
         The user query is translated into the brain language, answered, and the
         answer translated back (both no-ops unless ``enable_tx`` is set and the
         language differs from the brain language).
+
+        ``tools`` is accepted for ``ChatEngine`` contract conformance and
+        ignored: AIML is pure pattern matching and cannot invoke tools. The
+        agentic-loop ReAct fallback depends on non-tool engines being callable
+        with ``tools=``.
         """
         query = next((m.content for m in reversed(messages)
                       if m.role == MessageRole.USER), "")

--- a/test/test_query_translation.py
+++ b/test/test_query_translation.py
@@ -53,6 +53,27 @@ def test_non_english_query_translated_both_ways():
     assert reply.content.startswith("[en->pt]")
 
 
+def test_continue_chat_accepts_tools_kwarg_none():
+    """ChatEngine base contract: ``tools`` must be accepted (and ignored)
+    even though AIMLChatEngine is not tool-capable (pure pattern matching)."""
+    engine = AIMLChatEngine({"lang": "en-us"})
+    reply = engine.continue_chat(_user("hello"), lang="en-us", tools=None)
+    assert isinstance(reply, AgentMessage)
+    assert reply.role == MessageRole.ASSISTANT
+
+
+def test_continue_chat_accepts_tools_kwarg_list():
+    """Passing a non-empty ``tools`` list must not raise, since the base
+    ChatEngine.continue_chat wrapper may call subclasses with tools=."""
+    engine = AIMLChatEngine({"lang": "en-us"})
+    reply = engine.continue_chat(
+        _user("hello"), lang="en-us",
+        tools=[{"type": "function", "function": {"name": "noop"}}],
+    )
+    assert isinstance(reply, AgentMessage)
+    assert reply.role == MessageRole.ASSISTANT
+
+
 def test_missing_translator_degrades_gracefully():
     # enable_tx on, but no plugin available -> never raises, answers as-is
     engine = AIMLChatEngine({"lang": "en-us", "enable_tx": True})


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

The base ChatEngine takes a tools argument, but AIMLChatEngine dropped it from its own continue_chat, so anything passing tools= by keyword (like ovos_persona_server/server_tools.py) hit a TypeError. This went unnoticed because the base class's own wrappers call continue_chat positionally.

AIML is pattern matching and has no use for tools, but it still has to accept the argument and ignore it, because the agentic loop calls every engine the same way. supports_tools stays False.

I added two tests that pass tools=None and a real tool list into continue_chat and check it returns an AgentMessage without raising. Both fail on dev with the TypeError and pass here. Full suite (excluding test/end2end, which needs a running OVOS bus): 7 passed.
