### PR TITLE
feat: publish a docker image for a ready-to-run AimlBot persona

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.github
+test
+**/__pycache__
+*.py[cod]
+.pytest_cache
+*.egg-info
+.venv
+CHANGELOG.md

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,46 @@
+name: docker
+
+on:
+  push:
+    branches: [master, dev]
+    tags: ["*.*.*", "V*", "v*"]
+  pull_request:
+    paths:
+      - Dockerfile
+      - .dockerignore
+      - pyproject.toml
+      - .github/workflows/docker.yml
+  workflow_dispatch:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v7
+      - uses: docker/setup-buildx-action@v4
+      - id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master' }}
+            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' }}
+            type=ref,event=tag
+            type=sha,format=short
+      - uses: docker/login-action@v4
+        if: github.event_name != 'pull_request'
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+# ovos-persona-server serving a persona backed by this plugin's chat engine
+# (opm.agents.chat, AIMLChatEngine). No API key or other external credential
+# is needed -- AIML pattern matching runs entirely offline against the
+# bundled aiml_data.
+FROM python:3.12-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Prerelease floor: ovos-persona needs a version new enough to resolve a
+# chat-engine entry point as a persona handler.
+RUN pip install --no-cache-dir "ovos-persona>=0.9.0a9"
+
+# This plugin is installed from PyPI rather than the local checkout, so the
+# image always matches whatever release is public -- there is no local
+# source dependency to build from here.
+#
+# Pinned to the 0.0.2 alpha line: the latest stable release on PyPI, 0.0.1,
+# predates AIMLChatEngine and the opm.agents.chat entry point entirely (it
+# only ships the deprecated QuestionSolver class, which pulls in a hard
+# ovos-translate-plugin-server dependency this image does not carry and
+# fails to start). Verified against the published wheel: 0.0.2a6 registers
+# "opm.agents.chat = ovos_solver_aiml_plugin:AIMLChatEngine"; 0.0.1 does not
+# register opm.agents.chat at all.
+RUN pip install --no-cache-dir "ovos-solver-aiml-plugin>=0.0.2a6"
+
+# [mcp] mounts the MCP tool endpoint. From 0.17.0a1 that mount is opt-in --
+# installing the extra alone no longer flips it on, so --mcp below is
+# required, matching ovos-plugin-linguonnx's image.
+RUN pip install --no-cache-dir "ovos-persona-server[mcp]>=0.17.0a1"
+
+# The persona JSON: "handlers" (the modern config key; "solvers" is kept as
+# a legacy alias) points at this plugin by its opm.agents.chat id.
+RUN mkdir -p /personas && printf '%s\n' \
+    '{' \
+    '  "name": "AimlBot",' \
+    '  "handlers": ["ovos-solver-aiml-plugin"]' \
+    '}' > /personas/aimlbot.json
+
+EXPOSE 8337
+
+ENTRYPOINT ["ovos-persona-server", "--personas-dir", "/personas", "--mcp", \
+            "--port", "8337", "--host", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -78,6 +78,41 @@ so on) are skipped, and exports never emit residual `<…>` markup. See
 - [OpenVoiceOS/ovos-plugin-manager](https://github.com/OpenVoiceOS/ovos-plugin-manager): loads this plugin through the `opm.agents.chat` entry point.
 - [OpenVoiceOS/ovos-translate-plugin-server](https://github.com/OpenVoiceOS/ovos-translate-plugin-server): recommended remote translate plugin for `enable_tx`.
 
+## Docker
+
+This repo publishes `ghcr.io/openvoiceos/ovos-solver-plugin-aiml`, a
+standalone `ovos-persona-server` that serves one persona, `AimlBot`, backed
+by the `AIMLChatEngine` in this plugin. Matching runs entirely offline
+against the bundled `aiml_data`, so the image needs no key and no network
+access to answer.
+
+```bash
+docker run -p 8391:8337 ghcr.io/openvoiceos/ovos-solver-plugin-aiml:dev
+```
+
+```bash
+curl http://localhost:8391/v1/models
+curl http://localhost:8391/v1/chat/completions \
+    -H "Content-Type: application/json" \
+    -d '{"model": "AimlBot", "messages": [{"role": "user", "content": "hello"}]}'
+```
+
+A compose snippet:
+
+```yaml
+services:
+  ovos-aiml-persona:
+    image: ghcr.io/openvoiceos/ovos-solver-plugin-aiml:dev
+    ports:
+      - "8391:8337"
+    restart: unless-stopped
+```
+
+The image builds on every pull request touching `Dockerfile`,
+`.dockerignore`, `pyproject.toml`, or the docker workflow itself (build only,
+no push), and publishes on pushes to `master` (`latest`), `dev` (`dev`), and
+version tags. See the [`docker` workflow](.github/workflows/docker.yml).
+
 ## License
 
 [Apache License 2.0](LICENSE)


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

This adds a Dockerfile and a docker workflow so the plugin can be deployed as a running service instead of built locally every time. The image runs ovos-persona-server with a single persona, AimlBot, whose handler is this plugin's AIMLChatEngine. AIML matching runs entirely offline against the bundled aiml_data, so the container needs no key and no network access to answer.

The structure copies OpenVoiceOS/ovos-plugin-linguonnx exactly: same base image, same docker workflow that builds on relevant pull requests and pushes to ghcr.io on master, dev, and tags, same use of the [mcp] extra plus --mcp on ovos-persona-server. The plugin is installed from PyPI, pinned to >=0.0.2a6. That pin matters: the latest stable release, 0.0.1, predates AIMLChatEngine entirely and does not register the opm.agents.chat entry point, so a plain `pip install ovos-solver-aiml-plugin` builds an image that crashes on start trying to load the old QuestionSolver class, which pulls in a hard dependency on ovos-translate-plugin-server that isn't in the image. I found this by building the image straight against 0.0.1 first, watching it fail, and checking the published wheel's entry_points.txt at each alpha until I found the one that actually ships the chat engine.

I built and ran the image on the ser9 box and did a real round trip through POST /v1/chat/completions: sent {"model": "AimlBot", "messages": [{"role": "user", "content": "hello"}]} and got back "Hi there!" from the running container.

Tests: ran pytest against test/ the same way CI does (pip install -e .[test], pytest test). 12 passed, 0 failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Dockerized offline AIML persona server.
  * Exposes the server on port 8337 with MCP support enabled.
  * Added automated Docker image builds and publishing.
  * Added Docker Compose and API usage guidance.

* **Documentation**
  * Documented image usage, offline behavior, configuration, and build triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->