### PR TITLE
fix: e2e test asserts current speak topic, not legacy one

### DIFF
--- a/test/end2end/test_e2e_persona_pipeline.py
+++ b/test/end2end/test_e2e_persona_pipeline.py
@@ -133,7 +133,7 @@ class TestAimlPersonaSpeaksThroughPipeline:
         messages = _drive_utterance(mc, sess, TEST_UTTERANCE, timeout=60)
 
         msg_types = [m.msg_type for m in messages]
-        speak_msgs = [m for m in messages if m.msg_type == "speak"]
+        speak_msgs = [m for m in messages if m.msg_type == "ovos.utterance.speak"]
 
         assert speak_msgs, (
             f"Expected at least one 'speak' message; got msg_types: {msg_types}"
@@ -162,7 +162,7 @@ class TestAimlPersonaSpeaksThroughPipeline:
         messages = _drive_utterance(mc, sess, "what is your name", timeout=60)
 
         for msg in messages:
-            if msg.msg_type == "speak":
+            if msg.msg_type == "ovos.utterance.speak":
                 assert msg.data.get("utterance", "").strip(), (
                     f"speak message has empty utterance: {msg.data}"
                 )


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Sonnet 5 (claude-sonnet-5) via Claude Code — NOT human-reviewed. Verify before acting.

test/end2end/test_e2e_persona_pipeline.py checks msg.msg_type == "speak" in two places, but the stack now emits "ovos.utterance.speak" (ovos_spec_tools.messages.SpecMessage.SPEAK). I found this while working on an unrelated identity fix in this repo and ran the class against unmodified dev to make sure it wasn't something I'd broken - it fails there too, identically, so this is a pre-existing defect and not new breakage. It blocks CI on any PR that touches this test file, since both tests in TestAimlPersonaSpeaksThroughPipeline never find a message with the old topic name and fail with "Expected at least one 'speak' message".

This is a one-line-per-site fix: the two literal "speak" comparisons become "ovos.utterance.speak". No behavior changes outside the test file.
